### PR TITLE
Adicionada classe Obstacle

### DIFF
--- a/Obstacle.cpp
+++ b/Obstacle.cpp
@@ -1,0 +1,104 @@
+#include "Obstacle.hpp"
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/Rect.hpp>
+
+Obstacle::Obstacle() : m_texture(NULL)
+{
+	m_textureRect = sf::IntRect();
+}
+
+Obstacle::Obstacle(const sf::Texture& texture, const sf::IntRect& rectangle, int x, int y){
+	sf::IntRect rect;	
+
+	this->m_texture = &texture;
+
+	if(rectangle == sf::IntRect()) {
+		rect = sf::IntRect(0,0,texture.getSize().x,texture.getSize().y);
+	}
+	else {
+		rect = rectangle;
+	}
+
+	m_textureRect = rect;
+
+	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
+    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+
+    float left = static_cast<float>(rect.left) + 0.0001f;
+    float right = left + static_cast<float>(rect.width);
+    float top = static_cast<float>(rect.top);
+    float bottom = top + static_cast<float>(rect.height);
+
+    m_vertices[0].texCoords = sf::Vector2f(left, top);
+    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+    m_vertices[3].texCoords = sf::Vector2f(right, top);
+
+    this->setPosition(x,y);
+    this->setRaio(0);
+}
+
+void Obstacle::setTexture(const sf::Texture& textura){
+	this->m_texture = &textura;
+	sf::IntRect rect = sf::IntRect(0,0,textura.getSize().x,textura.getSize().y);
+	m_textureRect = rect;
+
+	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
+    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+
+    float left = static_cast<float>(rect.left) + 0.0001f;
+    float right = left + static_cast<float>(rect.width);
+    float top = static_cast<float>(rect.top);
+    float bottom = top + static_cast<float>(rect.height);
+
+    m_vertices[0].texCoords = sf::Vector2f(left, top);
+    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+    m_vertices[3].texCoords = sf::Vector2f(right, top);
+}
+
+const sf::Texture* Obstacle::getTexture() const
+{
+	return m_texture;
+}
+
+void Obstacle::setTextureRect(const sf::IntRect& rect){
+	m_textureRect = rect;
+
+	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
+    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+
+    float left = static_cast<float>(rect.left) + 0.0001f;
+    float right = left + static_cast<float>(rect.width);
+    float top = static_cast<float>(rect.top);
+    float bottom = top + static_cast<float>(rect.height);
+
+    m_vertices[0].texCoords = sf::Vector2f(left, top);
+    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+    m_vertices[3].texCoords = sf::Vector2f(right, top);
+}
+
+const sf::IntRect& Obstacle::getTextureRect() const
+{
+	return m_textureRect;
+}
+
+void Obstacle::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    if (m_texture)
+    {
+        states.transform *= getTransform();
+        states.texture = m_texture;
+        target.draw(m_vertices, 4, sf::TriangleStrip, states);
+    }
+}

--- a/Obstacle.cpp
+++ b/Obstacle.cpp
@@ -25,22 +25,22 @@ Obstacle::Obstacle(const sf::Texture& texture, const sf::IntRect& rectangle, int
 	m_textureRect = rect;
 
 	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
-    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
-    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
-    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+	m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+	m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+	m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
 
-    float left = static_cast<float>(rect.left) + 0.0001f;
-    float right = left + static_cast<float>(rect.width);
-    float top = static_cast<float>(rect.top);
-    float bottom = top + static_cast<float>(rect.height);
+	float left = static_cast<float>(rect.left) + 0.0001f;
+	float right = left + static_cast<float>(rect.width);
+	float top = static_cast<float>(rect.top);
+	float bottom = top + static_cast<float>(rect.height);
 
-    m_vertices[0].texCoords = sf::Vector2f(left, top);
-    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
-    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
-    m_vertices[3].texCoords = sf::Vector2f(right, top);
+	m_vertices[0].texCoords = sf::Vector2f(left, top);
+	m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+	m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+	m_vertices[3].texCoords = sf::Vector2f(right, top);
 
-    this->setPosition(x,y);
-    this->setRaio(0);
+	this->setPosition(x,y);
+	this->setRaio(0);
 }
 
 void Obstacle::setTexture(const sf::Texture& textura){
@@ -49,19 +49,19 @@ void Obstacle::setTexture(const sf::Texture& textura){
 	m_textureRect = rect;
 
 	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
-    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
-    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
-    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+	m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+	m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+	m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
 
-    float left = static_cast<float>(rect.left) + 0.0001f;
-    float right = left + static_cast<float>(rect.width);
-    float top = static_cast<float>(rect.top);
-    float bottom = top + static_cast<float>(rect.height);
+	float left = static_cast<float>(rect.left) + 0.0001f;
+	float right = left + static_cast<float>(rect.width);
+	float top = static_cast<float>(rect.top);
+	float bottom = top + static_cast<float>(rect.height);
 
-    m_vertices[0].texCoords = sf::Vector2f(left, top);
-    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
-    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
-    m_vertices[3].texCoords = sf::Vector2f(right, top);
+	m_vertices[0].texCoords = sf::Vector2f(left, top);
+	m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+	m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+	m_vertices[3].texCoords = sf::Vector2f(right, top);
 }
 
 const sf::Texture* Obstacle::getTexture() const
@@ -73,19 +73,19 @@ void Obstacle::setTextureRect(const sf::IntRect& rect){
 	m_textureRect = rect;
 
 	m_vertices[0].position = sf::Vector2f(0.f, 0.f);
-    m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
-    m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
-    m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
+	m_vertices[1].position = sf::Vector2f(0.f, static_cast<float>(rect.height));
+	m_vertices[2].position = sf::Vector2f(static_cast<float>(rect.width), static_cast<float>(rect.height));
+	m_vertices[3].position = sf::Vector2f(static_cast<float>(rect.width), 0.f);
 
-    float left = static_cast<float>(rect.left) + 0.0001f;
-    float right = left + static_cast<float>(rect.width);
-    float top = static_cast<float>(rect.top);
-    float bottom = top + static_cast<float>(rect.height);
+	float left = static_cast<float>(rect.left) + 0.0001f;
+	float right = left + static_cast<float>(rect.width);
+	float top = static_cast<float>(rect.top);
+	float bottom = top + static_cast<float>(rect.height);
 
-    m_vertices[0].texCoords = sf::Vector2f(left, top);
-    m_vertices[1].texCoords = sf::Vector2f(left, bottom);
-    m_vertices[2].texCoords = sf::Vector2f(right, bottom);
-    m_vertices[3].texCoords = sf::Vector2f(right, top);
+	m_vertices[0].texCoords = sf::Vector2f(left, top);
+	m_vertices[1].texCoords = sf::Vector2f(left, bottom);
+	m_vertices[2].texCoords = sf::Vector2f(right, bottom);
+	m_vertices[3].texCoords = sf::Vector2f(right, top);
 }
 
 const sf::IntRect& Obstacle::getTextureRect() const

--- a/Obstacle.hpp
+++ b/Obstacle.hpp
@@ -1,0 +1,32 @@
+#ifndef OBSTACLE_INCLUDE
+#define OBSTACLE_INCLUDE
+
+#include "Rigidbody.hpp"
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/Rect.hpp>
+
+class Obstacle : public sf::Drawable, public Rigidbody
+{
+public: 
+	Obstacle();
+	Obstacle(const sf::Texture& texture, const sf::IntRect& rectangle = sf::IntRect(), int x = 0, int y = 0);
+	void setTexture(const sf::Texture& textura);
+	const sf::Texture* getTexture() const;
+	void setTextureRect(const sf::IntRect& rect);
+	const sf::IntRect& getTextureRect() const; 
+
+
+private:
+	sf::Vertex m_vertices[4];
+	sf::IntRect m_textureRect;
+	const sf::Texture* m_texture;
+
+	virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+	
+};
+
+#endif

--- a/Rigidbody.cpp
+++ b/Rigidbody.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 Rigidbody::Rigidbody(){
+	this->raio = 0;
 }
 
 Rigidbody::Rigidbody(int raio){

--- a/Rigidbody.cpp
+++ b/Rigidbody.cpp
@@ -4,25 +4,25 @@
 #include <cmath>
 
 Rigidbody::Rigidbody(){
-	this->raio = 0;
+	this->raio_colisao = 0;
 }
 
 Rigidbody::Rigidbody(int raio){
-	this->raio = raio;
+	this->raio_colisao = raio;
 }
 
 void Rigidbody::setRaio(int raio){
-	this->raio = raio;
+	this->raio_colisao = raio;
 }
 
 int Rigidbody::getRaio(){
-	return this->raio;
+	return this->raio_colisao;
 }
 
 sf::Vector2f Rigidbody::colision(Rigidbody* another){
 	sf::Vector2f B = this->getPosition() - another->getPosition();
 	float dist = sqrt(B.x*B.x + B.y*B.y);
-	int radius_this = this->raio;
+	int radius_this = this->raio_colisao;
 	int radius_A = another->getRaio();
 	if(dist >= radius_A + radius_this){
 		return sf::Vector2f(0,0);

--- a/Rigidbody.hpp
+++ b/Rigidbody.hpp
@@ -14,7 +14,7 @@ public:
 	sf::Vector2f colision(Rigidbody* another);
 
 private:
-	int raio;
+	int raio_colisao;
 };
 
 #endif


### PR DESCRIPTION
Obstacle.hpp
Obstacle.cpp

#### Classe Obstacle adicionada. Motivos: 
* Classe parecida com sf::Sprite, porém herda Rigidbody o que torna sua utilização para obstáculos, como pedras, mais fácil.
* AnimatedSprite tem muitos métodos e atributos desnecessários para obstáculos deste tipo, uma vez que não necessitam de animações.

Rigidbody.cpp

* Mudado construtor para evitar possíveis problemas caso se esqueça de setar um raio. Agora, não haverá colisão se esquecer de seta-lo. 